### PR TITLE
feat(widgets): XR input + focus manager (#60)

### DIFF
--- a/addons/godot-charts/plugin.gd
+++ b/addons/godot-charts/plugin.gd
@@ -163,6 +163,10 @@ func _enable_plugin() -> void:
 		preload("widgets/widget_list_item_3d.gd"),
 		null
 	)
+	add_autoload_singleton(
+		"WidgetFocusManager",
+		"res://addons/godot-charts/widgets/widget_focus_manager.gd"
+	)
 
 
 func _disable_plugin() -> void:
@@ -191,4 +195,5 @@ func _disable_plugin() -> void:
 	remove_custom_type("WidgetButton3D")
 	remove_custom_type("WidgetToggle3D")
 	remove_custom_type("WidgetSlider3D")
+	remove_autoload_singleton("WidgetFocusManager")
 	remove_custom_type("WidgetListItem3D")

--- a/addons/godot-charts/widgets/widget_control_3d.gd
+++ b/addons/godot-charts/widgets/widget_control_3d.gd
@@ -29,10 +29,14 @@ signal pointer_event(event)
 		_queue_rebuild()
 
 var _state: State = State.NORMAL
+var _keyboard_focused: bool = false
 var _rebuild_queued: bool = false
 var _bg_mat: StandardMaterial3D
 var _border_mat: StandardMaterial3D
+var _border_inst: MeshInstance3D
 var _shape: CollisionShape3D
+
+const _BORDER_W: float = 0.006  # 6 mm frame around each control
 
 
 func _ready() -> void:
@@ -47,6 +51,16 @@ func _ready() -> void:
 		mouse_entered.connect(_on_mouse_entered)
 		mouse_exited.connect(_on_mouse_exited)
 		input_event.connect(_on_input_event)
+		var fm := _get_focus_manager()
+		if fm:
+			fm.register(self)
+
+
+func _exit_tree() -> void:
+	if not Engine.is_editor_hint():
+		var fm := _get_focus_manager()
+		if fm:
+			fm.unregister(self)
 
 
 func _process(_delta: float) -> void:
@@ -75,12 +89,26 @@ func _ensure_children() -> void:
 	if not is_instance_valid(_bg_mat):
 		_bg_mat = StandardMaterial3D.new()
 		_bg_mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	if not is_instance_valid(_border_mat):
+		_border_mat = StandardMaterial3D.new()
+		_border_mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	if not is_instance_valid(_border_inst):
+		_border_inst = MeshInstance3D.new()
+		_border_inst.name = "_border"
+		_border_inst.material_override = _border_mat
+		add_child(_border_inst)
 
 
 func _apply_shape() -> void:
 	var box := BoxShape3D.new()
 	box.size = Vector3(widget_size.x, widget_size.y, 0.002)
 	_shape.shape = box
+
+	var bw := _BORDER_W
+	var border_q := QuadMesh.new()
+	border_q.size = Vector2(widget_size.x + bw * 2.0, widget_size.y + bw * 2.0)
+	_border_inst.mesh = border_q
+	_border_inst.position = Vector3(0.0, 0.0, -0.0005)
 
 
 # ── color helpers ─────────────────────────────────────────────────────────────
@@ -101,12 +129,14 @@ func _get_text_color() -> Color:
 
 func _get_border_color() -> Color:
 	var t := theme_data
-	if _state == State.FOCUSED:
+	if _keyboard_focused:
 		return t.border_focused if t else Color(0.30, 0.65, 1.0)
 	return t.border_normal if t else Color(0.35, 0.35, 0.40)
 
 func _apply_colors() -> void:
 	_bg_mat.albedo_color = _get_bg_color()
+	if is_instance_valid(_border_mat):
+		_border_mat.albedo_color = _get_border_color()
 
 
 # ── state machine ─────────────────────────────────────────────────────────────
@@ -118,6 +148,36 @@ func _update_state(new_state: State) -> void:
 	_apply_colors()
 
 
+# ── keyboard focus (managed by WidgetFocusManager) ────────────────────────────
+
+func _on_focus_gained() -> void:
+	_keyboard_focused = true
+	_apply_colors()
+
+
+func _on_focus_lost() -> void:
+	_keyboard_focused = false
+	_apply_colors()
+
+
+func _unhandled_key_input(event: InputEvent) -> void:
+	if not _keyboard_focused or not enabled:
+		return
+	if event is InputEventKey and event.pressed and not event.echo:
+		var fm := _get_focus_manager()
+		if not fm:
+			return
+		if event.keycode == KEY_TAB:
+			if event.shift_pressed:
+				fm.focus_prev(self)
+			else:
+				fm.focus_next(self)
+			get_viewport().set_input_as_handled()
+		elif event.keycode == KEY_ENTER or event.keycode == KEY_SPACE:
+			_on_clicked()
+			get_viewport().set_input_as_handled()
+
+
 # ── desktop interaction ───────────────────────────────────────────────────────
 
 func _on_mouse_entered() -> void:
@@ -126,11 +186,13 @@ func _on_mouse_entered() -> void:
 	_update_state(State.HOVER)
 	emit_signal("focus_entered")
 
+
 func _on_mouse_exited() -> void:
 	if not enabled:
 		return
 	_update_state(State.NORMAL)
 	emit_signal("focus_exited")
+
 
 func _on_input_event(_camera: Node, event: InputEvent, _pos: Vector3, _normal: Vector3, _idx: int) -> void:
 	if not enabled:
@@ -140,23 +202,36 @@ func _on_input_event(_camera: Node, event: InputEvent, _pos: Vector3, _normal: V
 		if mb.button_index == MOUSE_BUTTON_LEFT:
 			_update_state(State.PRESSED if mb.pressed else State.HOVER)
 			if not mb.pressed:
+				var fm := _get_focus_manager()
+				if fm:
+					fm.request_focus(self, fm.InputMode.DESKTOP)
 				_on_clicked()
 
 
 # ── XR pointer (godot-xr-tools) ──────────────────────────────────────────────
 
+## Called by XRToolsPointerEvent.report() when this node is the pointer target.
+## event_type values: 0=ENTERED 1=EXITED 2=PRESSED 3=RELEASED 4=MOVED
 func pointer_event(event: Object) -> void:
 	emit_signal("pointer_event", event)
 	if not enabled:
 		return
 	var t: int = event.get("event_type") if event else -1
 	match t:
-		1: _update_state(State.HOVER)   # ENTERED
-		2: _update_state(State.NORMAL)  # EXITED
-		3:                               # PRESSED
+		0:  # ENTERED
+			_update_state(State.HOVER)
+			emit_signal("focus_entered")
+		1:  # EXITED
+			_update_state(State.NORMAL)
+			emit_signal("focus_exited")
+		2:  # PRESSED
 			_update_state(State.PRESSED)
+			var fm := _get_focus_manager()
+			if fm:
+				fm.request_focus(self, fm.InputMode.XR)
 			_on_clicked()
-		4: _update_state(State.HOVER)   # RELEASED
+		3:  # RELEASED
+			_update_state(State.HOVER)
 
 
 # ── override point ────────────────────────────────────────────────────────────
@@ -165,6 +240,13 @@ func pointer_event(event: Object) -> void:
 func _on_clicked() -> void:
 	pass
 
+
 ## Return preferred size for layout containers.
 func get_widget_size() -> Vector2:
 	return widget_size
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+func _get_focus_manager() -> Node:
+	return get_node_or_null("/root/WidgetFocusManager")

--- a/addons/godot-charts/widgets/widget_focus_manager.gd
+++ b/addons/godot-charts/widgets/widget_focus_manager.gd
@@ -1,0 +1,80 @@
+extends Node
+
+## Emitted when keyboard or XR focus moves to a new widget (or clears to null).
+signal focus_changed(old_widget: Node, new_widget: Node)
+
+## How the focused widget received focus.
+enum InputMode { NONE, KEYBOARD, DESKTOP, XR }
+
+var _focused: Object = null
+var _input_mode: InputMode = InputMode.NONE
+var _registered: Array = []
+
+
+## Register a WidgetControl3D so Tab navigation can reach it.
+func register(widget) -> void:
+	if not _registered.has(widget):
+		_registered.append(widget)
+
+
+## Unregister a widget (called from _exit_tree).
+func unregister(widget) -> void:
+	_registered.erase(widget)
+	if _focused == widget:
+		_focused = null
+		_input_mode = InputMode.NONE
+
+
+## Move keyboard/XR focus to widget.  Pass null to clear focus.
+func request_focus(widget, mode: InputMode = InputMode.DESKTOP) -> void:
+	if _focused == widget:
+		return
+	var old = _focused
+	if is_instance_valid(old) and old.has_method("_on_focus_lost"):
+		old._on_focus_lost()
+	_focused = widget
+	_input_mode = mode
+	if is_instance_valid(widget) and widget.has_method("_on_focus_gained"):
+		widget._on_focus_gained()
+	focus_changed.emit(old, widget)
+
+
+## Release focus if widget currently holds it.
+func release_focus(widget) -> void:
+	if _focused != widget:
+		return
+	request_focus(null, InputMode.NONE)
+
+
+## Move focus to the next registered widget (Tab).
+func focus_next(from) -> void:
+	_cycle(from, 1)
+
+
+## Move focus to the previous registered widget (Shift+Tab).
+func focus_prev(from) -> void:
+	_cycle(from, -1)
+
+
+## Return the currently focused widget, or null.
+func get_focused() -> Object:
+	return _focused
+
+
+## Return the InputMode used to acquire current focus.
+func get_input_mode() -> InputMode:
+	return _input_mode
+
+
+func _cycle(from, dir: int) -> void:
+	var active: Array = _registered.filter(
+		func(w): return is_instance_valid(w) and w.enabled and w.is_visible_in_tree()
+	)
+	if active.is_empty():
+		return
+	var idx: int = active.find(from)
+	if idx == -1:
+		idx = 0
+	else:
+		idx = (idx + dir + active.size()) % active.size()
+	request_focus(active[idx], InputMode.KEYBOARD)

--- a/addons/godot-charts/widgets/widget_slider_3d.gd
+++ b/addons/godot-charts/widgets/widget_slider_3d.gd
@@ -40,6 +40,10 @@ var _dragging: bool = false
 var _drag_start_x: float = 0.0
 var _drag_start_val: float = 0.0
 
+var _xr_dragging: bool = false
+var _xr_drag_start_x: float = 0.0
+var _xr_drag_start_val: float = 0.0
+
 
 func _rebuild() -> void:
 	super._rebuild()
@@ -137,3 +141,28 @@ func _on_input_event(camera: Node, event: InputEvent, pos: Vector3, normal: Vect
 		if step > 0.0:
 			new_val = roundf(new_val / step) * step
 		value = clampf(new_val, min_value, max_value)
+
+
+## Handle XR MOVED events for drag-to-scrub.
+## event_type: 0=ENTERED 1=EXITED 2=PRESSED 3=RELEASED 4=MOVED
+func pointer_event(event: Object) -> void:
+	super.pointer_event(event)
+	if not enabled or not event:
+		return
+	var t: int = event.get("event_type")
+	match t:
+		2:  # PRESSED — begin XR drag
+			_xr_dragging = true
+			_xr_drag_start_x = to_local(event.get("position")).x
+			_xr_drag_start_val = value
+		3:  # RELEASED — end XR drag
+			_xr_dragging = false
+		4:  # MOVED — scrub slider
+			if _xr_dragging:
+				var lx := to_local(event.get("position")).x
+				var dx := lx - _xr_drag_start_x
+				var range_val := max_value - min_value
+				var new_val := _xr_drag_start_val + dx / widget_size.x * range_val
+				if step > 0.0:
+					new_val = roundf(new_val / step) * step
+				value = clampf(new_val, min_value, max_value)

--- a/demo/addons/godot-charts/plugin.gd
+++ b/demo/addons/godot-charts/plugin.gd
@@ -163,6 +163,10 @@ func _enable_plugin() -> void:
 		preload("widgets/widget_list_item_3d.gd"),
 		null
 	)
+	add_autoload_singleton(
+		"WidgetFocusManager",
+		"res://addons/godot-charts/widgets/widget_focus_manager.gd"
+	)
 
 
 func _disable_plugin() -> void:
@@ -191,4 +195,5 @@ func _disable_plugin() -> void:
 	remove_custom_type("WidgetButton3D")
 	remove_custom_type("WidgetToggle3D")
 	remove_custom_type("WidgetSlider3D")
+	remove_autoload_singleton("WidgetFocusManager")
 	remove_custom_type("WidgetListItem3D")

--- a/demo/addons/godot-charts/widgets/widget_control_3d.gd
+++ b/demo/addons/godot-charts/widgets/widget_control_3d.gd
@@ -29,10 +29,14 @@ signal pointer_event(event)
 		_queue_rebuild()
 
 var _state: State = State.NORMAL
+var _keyboard_focused: bool = false
 var _rebuild_queued: bool = false
 var _bg_mat: StandardMaterial3D
 var _border_mat: StandardMaterial3D
+var _border_inst: MeshInstance3D
 var _shape: CollisionShape3D
+
+const _BORDER_W: float = 0.006  # 6 mm frame around each control
 
 
 func _ready() -> void:
@@ -47,6 +51,16 @@ func _ready() -> void:
 		mouse_entered.connect(_on_mouse_entered)
 		mouse_exited.connect(_on_mouse_exited)
 		input_event.connect(_on_input_event)
+		var fm := _get_focus_manager()
+		if fm:
+			fm.register(self)
+
+
+func _exit_tree() -> void:
+	if not Engine.is_editor_hint():
+		var fm := _get_focus_manager()
+		if fm:
+			fm.unregister(self)
 
 
 func _process(_delta: float) -> void:
@@ -75,12 +89,26 @@ func _ensure_children() -> void:
 	if not is_instance_valid(_bg_mat):
 		_bg_mat = StandardMaterial3D.new()
 		_bg_mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	if not is_instance_valid(_border_mat):
+		_border_mat = StandardMaterial3D.new()
+		_border_mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	if not is_instance_valid(_border_inst):
+		_border_inst = MeshInstance3D.new()
+		_border_inst.name = "_border"
+		_border_inst.material_override = _border_mat
+		add_child(_border_inst)
 
 
 func _apply_shape() -> void:
 	var box := BoxShape3D.new()
 	box.size = Vector3(widget_size.x, widget_size.y, 0.002)
 	_shape.shape = box
+
+	var bw := _BORDER_W
+	var border_q := QuadMesh.new()
+	border_q.size = Vector2(widget_size.x + bw * 2.0, widget_size.y + bw * 2.0)
+	_border_inst.mesh = border_q
+	_border_inst.position = Vector3(0.0, 0.0, -0.0005)
 
 
 # ── color helpers ─────────────────────────────────────────────────────────────
@@ -101,12 +129,14 @@ func _get_text_color() -> Color:
 
 func _get_border_color() -> Color:
 	var t := theme_data
-	if _state == State.FOCUSED:
+	if _keyboard_focused:
 		return t.border_focused if t else Color(0.30, 0.65, 1.0)
 	return t.border_normal if t else Color(0.35, 0.35, 0.40)
 
 func _apply_colors() -> void:
 	_bg_mat.albedo_color = _get_bg_color()
+	if is_instance_valid(_border_mat):
+		_border_mat.albedo_color = _get_border_color()
 
 
 # ── state machine ─────────────────────────────────────────────────────────────
@@ -118,6 +148,36 @@ func _update_state(new_state: State) -> void:
 	_apply_colors()
 
 
+# ── keyboard focus (managed by WidgetFocusManager) ────────────────────────────
+
+func _on_focus_gained() -> void:
+	_keyboard_focused = true
+	_apply_colors()
+
+
+func _on_focus_lost() -> void:
+	_keyboard_focused = false
+	_apply_colors()
+
+
+func _unhandled_key_input(event: InputEvent) -> void:
+	if not _keyboard_focused or not enabled:
+		return
+	if event is InputEventKey and event.pressed and not event.echo:
+		var fm := _get_focus_manager()
+		if not fm:
+			return
+		if event.keycode == KEY_TAB:
+			if event.shift_pressed:
+				fm.focus_prev(self)
+			else:
+				fm.focus_next(self)
+			get_viewport().set_input_as_handled()
+		elif event.keycode == KEY_ENTER or event.keycode == KEY_SPACE:
+			_on_clicked()
+			get_viewport().set_input_as_handled()
+
+
 # ── desktop interaction ───────────────────────────────────────────────────────
 
 func _on_mouse_entered() -> void:
@@ -126,11 +186,13 @@ func _on_mouse_entered() -> void:
 	_update_state(State.HOVER)
 	emit_signal("focus_entered")
 
+
 func _on_mouse_exited() -> void:
 	if not enabled:
 		return
 	_update_state(State.NORMAL)
 	emit_signal("focus_exited")
+
 
 func _on_input_event(_camera: Node, event: InputEvent, _pos: Vector3, _normal: Vector3, _idx: int) -> void:
 	if not enabled:
@@ -140,23 +202,36 @@ func _on_input_event(_camera: Node, event: InputEvent, _pos: Vector3, _normal: V
 		if mb.button_index == MOUSE_BUTTON_LEFT:
 			_update_state(State.PRESSED if mb.pressed else State.HOVER)
 			if not mb.pressed:
+				var fm := _get_focus_manager()
+				if fm:
+					fm.request_focus(self, fm.InputMode.DESKTOP)
 				_on_clicked()
 
 
 # ── XR pointer (godot-xr-tools) ──────────────────────────────────────────────
 
+## Called by XRToolsPointerEvent.report() when this node is the pointer target.
+## event_type values: 0=ENTERED 1=EXITED 2=PRESSED 3=RELEASED 4=MOVED
 func pointer_event(event: Object) -> void:
 	emit_signal("pointer_event", event)
 	if not enabled:
 		return
 	var t: int = event.get("event_type") if event else -1
 	match t:
-		1: _update_state(State.HOVER)   # ENTERED
-		2: _update_state(State.NORMAL)  # EXITED
-		3:                               # PRESSED
+		0:  # ENTERED
+			_update_state(State.HOVER)
+			emit_signal("focus_entered")
+		1:  # EXITED
+			_update_state(State.NORMAL)
+			emit_signal("focus_exited")
+		2:  # PRESSED
 			_update_state(State.PRESSED)
+			var fm := _get_focus_manager()
+			if fm:
+				fm.request_focus(self, fm.InputMode.XR)
 			_on_clicked()
-		4: _update_state(State.HOVER)   # RELEASED
+		3:  # RELEASED
+			_update_state(State.HOVER)
 
 
 # ── override point ────────────────────────────────────────────────────────────
@@ -165,6 +240,13 @@ func pointer_event(event: Object) -> void:
 func _on_clicked() -> void:
 	pass
 
+
 ## Return preferred size for layout containers.
 func get_widget_size() -> Vector2:
 	return widget_size
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+func _get_focus_manager() -> Node:
+	return get_node_or_null("/root/WidgetFocusManager")

--- a/demo/addons/godot-charts/widgets/widget_focus_manager.gd
+++ b/demo/addons/godot-charts/widgets/widget_focus_manager.gd
@@ -1,0 +1,80 @@
+extends Node
+
+## Emitted when keyboard or XR focus moves to a new widget (or clears to null).
+signal focus_changed(old_widget: Node, new_widget: Node)
+
+## How the focused widget received focus.
+enum InputMode { NONE, KEYBOARD, DESKTOP, XR }
+
+var _focused: Object = null
+var _input_mode: InputMode = InputMode.NONE
+var _registered: Array = []
+
+
+## Register a WidgetControl3D so Tab navigation can reach it.
+func register(widget) -> void:
+	if not _registered.has(widget):
+		_registered.append(widget)
+
+
+## Unregister a widget (called from _exit_tree).
+func unregister(widget) -> void:
+	_registered.erase(widget)
+	if _focused == widget:
+		_focused = null
+		_input_mode = InputMode.NONE
+
+
+## Move keyboard/XR focus to widget.  Pass null to clear focus.
+func request_focus(widget, mode: InputMode = InputMode.DESKTOP) -> void:
+	if _focused == widget:
+		return
+	var old = _focused
+	if is_instance_valid(old) and old.has_method("_on_focus_lost"):
+		old._on_focus_lost()
+	_focused = widget
+	_input_mode = mode
+	if is_instance_valid(widget) and widget.has_method("_on_focus_gained"):
+		widget._on_focus_gained()
+	focus_changed.emit(old, widget)
+
+
+## Release focus if widget currently holds it.
+func release_focus(widget) -> void:
+	if _focused != widget:
+		return
+	request_focus(null, InputMode.NONE)
+
+
+## Move focus to the next registered widget (Tab).
+func focus_next(from) -> void:
+	_cycle(from, 1)
+
+
+## Move focus to the previous registered widget (Shift+Tab).
+func focus_prev(from) -> void:
+	_cycle(from, -1)
+
+
+## Return the currently focused widget, or null.
+func get_focused() -> Object:
+	return _focused
+
+
+## Return the InputMode used to acquire current focus.
+func get_input_mode() -> InputMode:
+	return _input_mode
+
+
+func _cycle(from, dir: int) -> void:
+	var active: Array = _registered.filter(
+		func(w): return is_instance_valid(w) and w.enabled and w.is_visible_in_tree()
+	)
+	if active.is_empty():
+		return
+	var idx: int = active.find(from)
+	if idx == -1:
+		idx = 0
+	else:
+		idx = (idx + dir + active.size()) % active.size()
+	request_focus(active[idx], InputMode.KEYBOARD)

--- a/demo/addons/godot-charts/widgets/widget_slider_3d.gd
+++ b/demo/addons/godot-charts/widgets/widget_slider_3d.gd
@@ -40,6 +40,10 @@ var _dragging: bool = false
 var _drag_start_x: float = 0.0
 var _drag_start_val: float = 0.0
 
+var _xr_dragging: bool = false
+var _xr_drag_start_x: float = 0.0
+var _xr_drag_start_val: float = 0.0
+
 
 func _rebuild() -> void:
 	super._rebuild()
@@ -137,3 +141,28 @@ func _on_input_event(camera: Node, event: InputEvent, pos: Vector3, normal: Vect
 		if step > 0.0:
 			new_val = roundf(new_val / step) * step
 		value = clampf(new_val, min_value, max_value)
+
+
+## Handle XR MOVED events for drag-to-scrub.
+## event_type: 0=ENTERED 1=EXITED 2=PRESSED 3=RELEASED 4=MOVED
+func pointer_event(event: Object) -> void:
+	super.pointer_event(event)
+	if not enabled or not event:
+		return
+	var t: int = event.get("event_type")
+	match t:
+		2:  # PRESSED — begin XR drag
+			_xr_dragging = true
+			_xr_drag_start_x = to_local(event.get("position")).x
+			_xr_drag_start_val = value
+		3:  # RELEASED — end XR drag
+			_xr_dragging = false
+		4:  # MOVED — scrub slider
+			if _xr_dragging:
+				var lx := to_local(event.get("position")).x
+				var dx := lx - _xr_drag_start_x
+				var range_val := max_value - min_value
+				var new_val := _xr_drag_start_val + dx / widget_size.x * range_val
+				if step > 0.0:
+					new_val = roundf(new_val / step) * step
+				value = clampf(new_val, min_value, max_value)


### PR DESCRIPTION
## Summary

- **Bug fix**: `WidgetControl3D.pointer_event()` XR event indices corrected from `1,2,3,4` → `0,1,2,3` (matching `XRToolsPointerEvent.Type`: ENTERED=0, EXITED=1, PRESSED=2, RELEASED=3)
- **New autoload**: `WidgetFocusManager` — tracks focus + input mode (KEYBOARD / DESKTOP / XR), Tab/Shift-Tab cycling, auto-registers all live `WidgetControl3D` instances; added to plugin `_enable_plugin` / `_disable_plugin`
- **Focus border visual**: 6 mm frame `QuadMesh` behind every control turns blue when keyboard-focused, visible in VR
- **Keyboard activation**: Tab / Shift-Tab cycles focus; Enter / Space activates the focused control
- **XR slider drag**: `WidgetSlider3D.pointer_event()` handles MOVED (type 4) to scrub value via world-space X position

Closes #60. Part of #56 Phase 1.

## Test plan

- [ ] Desktop: click a button → focus border appears; Tab cycles to next widget
- [ ] Desktop: slider mouse-drag still works
- [ ] XR: ray ENTER → hover; PRESS → focus border + action fires; RELEASE → hover
- [ ] XR: slider PRESS → MOVE scrubs value; RELEASE ends drag
- [ ] No focus deadlock: XR pointer focus does not prevent keyboard Tab from cycling

🤖 Generated with [Claude Code](https://claude.com/claude-code)