### PR TITLE
Add demo MessageBusService singleton scaffold

### DIFF
--- a/demo/scenes/DataBindingService.cs
+++ b/demo/scenes/DataBindingService.cs
@@ -44,6 +44,7 @@ private static readonly string[] NightHdriCandidates =
 
 private WorkspaceStateService? _workspaceService;
 private FrameOrchestrationService? _frameService;
+private MessageBusService? _messageBusService;
 private Node3D? _dataRoom;
 private Texture2D? _desktopPrototypeTexture;
 private WorldEnvironment? _worldEnvironment;
@@ -56,6 +57,7 @@ private readonly System.Collections.Generic.Dictionary<string, string> _framePre
 private readonly System.Collections.Generic.Dictionary<string, DesktopSourceProfile> _desktopSourceByFrame = new();
 private readonly System.Collections.Generic.Dictionary<string, string> _desktopSourceStatusByFrame = new();
 private readonly System.Collections.Generic.Dictionary<string, RuntimeBindingState> _stateByFrame = new();
+private readonly System.Collections.Generic.Dictionary<string, string> _topicByFrame = new();
 private string _environmentPreset = "daylight";
 private string _environmentStatus = "pending";
 private bool _loggedMissingEnvironmentNodes;
@@ -93,6 +95,18 @@ ResolveEnvironmentNodes();
 _workspaceService.WorkspaceLoaded += OnWorkspaceLoaded;
 _frameService.RuntimeFramesChanged += OnRuntimeFramesChanged;
 ApplyWorkspaceState();
+}
+
+public void BindMessageBus(MessageBusService messageBusService)
+{
+	if (_messageBusService == messageBusService)
+		return;
+
+	if (_messageBusService != null)
+		ClearMessageBusSubscriptions(_messageBusService);
+
+	_messageBusService = messageBusService;
+	SyncMessageBusSubscriptions();
 }
 
 public string GetEnvironmentPreset()
@@ -382,6 +396,7 @@ private void OnRuntimeFramesChanged()
 {
 SyncStateToRuntimeFrames();
 ApplyAllStateToRuntimeFrames();
+	SyncMessageBusSubscriptions();
 PersistState();
 EmitSignal(SignalName.FrameBindingsChanged);
 }
@@ -671,6 +686,7 @@ continue;
 if (_frameService.TryGetFrame(frameId, out var frame))
 ApplyBindingToFrame(frameId, frame);
 }
+	SyncMessageBusSubscriptions();
 }
 
 private void ApplyBindingToFrame(string frameId, ChartFrame3D frame)
@@ -1109,6 +1125,74 @@ _workspaceService.ActiveWorkspaceProfile[DesktopWindowsProfileKey] = windows;
 _workspaceService.ActiveWorkspaceProfile[DesktopSourcesProfileKey] = sources;
 _workspaceService.ActiveWorkspaceProfile[EnvironmentPresetProfileKey] = _environmentPreset;
 _workspaceService.SaveActiveWorkspace();
+}
+
+private void SyncMessageBusSubscriptions()
+{
+	if (_messageBusService == null || _frameService == null)
+	{
+		_topicByFrame.Clear();
+		return;
+	}
+
+	var expectedTopicsByFrame = new System.Collections.Generic.Dictionary<string, string>();
+	foreach (var profile in _frameService.ListRuntimeFrameProfiles())
+	{
+		if (!profile.TryGetValue("id", out var idVariant))
+			continue;
+
+		var frameId = idVariant.AsString();
+		if (string.IsNullOrWhiteSpace(frameId))
+			continue;
+
+		if (GetBindingKind(frameId) != BindingStream)
+			continue;
+
+		var chartType = _frameService.GetFrameChartType(frameId);
+		if (chartType == "desktop")
+			continue;
+
+		expectedTopicsByFrame[frameId] = BuildFrameTopic(frameId);
+	}
+
+	var removeIds = new List<string>();
+	foreach (var existing in _topicByFrame)
+	{
+		if (!expectedTopicsByFrame.TryGetValue(existing.Key, out var expectedTopic) || expectedTopic != existing.Value)
+		{
+			_messageBusService.UnregisterSubscriber(existing.Value, BuildSubscriberId(existing.Key));
+			removeIds.Add(existing.Key);
+		}
+	}
+
+	foreach (var frameId in removeIds)
+		_topicByFrame.Remove(frameId);
+
+	foreach (var expected in expectedTopicsByFrame)
+	{
+		if (_topicByFrame.TryGetValue(expected.Key, out var currentTopic) && currentTopic == expected.Value)
+			continue;
+
+		_messageBusService.RegisterSubscriber(expected.Value, BuildSubscriberId(expected.Key));
+		_topicByFrame[expected.Key] = expected.Value;
+	}
+}
+
+private void ClearMessageBusSubscriptions(MessageBusService service)
+{
+	foreach (var entry in _topicByFrame)
+		service.UnregisterSubscriber(entry.Value, BuildSubscriberId(entry.Key));
+	_topicByFrame.Clear();
+}
+
+private static string BuildFrameTopic(string frameId)
+{
+	return $"demo/frame/{frameId}";
+}
+
+private static string BuildSubscriberId(string frameId)
+{
+	return $"DataBindingService:{frameId}";
 }
 
 private static string NormalizeSourceKind(string sourceKind)

--- a/demo/scenes/Main.cs
+++ b/demo/scenes/Main.cs
@@ -49,6 +49,7 @@ public partial class Main : Node3D
     private WorkspaceStateService _workspaceService = null!;
     private FrameOrchestrationService _frameService = null!;
     private DataBindingService _bindingService = null!;
+    private MessageBusService _messageBusService = null!;
     private ConsoleRoot _consoleRoot = null!;
 
     public override void _Ready()
@@ -91,6 +92,10 @@ public partial class Main : Node3D
         _bindingService = new DataBindingService { Name = "DataBindingService" };
         AddChild(_bindingService);
         _bindingService.Initialize(_frameService, _workspaceService, GetNode<Node3D>("DataRoom"));
+
+        _messageBusService = new MessageBusService { Name = "MessageBusService" };
+        AddChild(_messageBusService);
+        _bindingService.BindMessageBus(_messageBusService);
 
         var packed = GD.Load<PackedScene>("res://scenes/console_root.tscn");
         _consoleRoot = packed.Instantiate<ConsoleRoot>();

--- a/demo/scenes/MessageBusService.cs
+++ b/demo/scenes/MessageBusService.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using Godot;
+using Godot.Collections;
+
+public partial class MessageBusService : Node
+{
+	[Signal]
+	public delegate void MessageReceivedEventHandler(string topic, Dictionary payload);
+
+	[Signal]
+	public delegate void RunningStateChangedEventHandler(bool isRunning);
+
+	private const double DefaultHeartbeatSeconds = 30.0;
+	private const string HeartbeatTopic = "bus/status";
+
+	private readonly System.Collections.Generic.Dictionary<string, HashSet<string>> _subscriberIdsByTopic = new();
+	private Timer? _heartbeatTimer;
+	private ulong _heartbeatTick;
+
+	public bool IsRunning { get; private set; }
+
+	public override void _Ready()
+	{
+		EnsureHeartbeatTimer(DefaultHeartbeatSeconds);
+		Start();
+	}
+
+	public void ConfigureHeartbeat(double intervalSeconds, bool restartIfRunning = true)
+	{
+		if (intervalSeconds <= 0.0)
+			intervalSeconds = DefaultHeartbeatSeconds;
+
+		EnsureHeartbeatTimer(intervalSeconds);
+		if (restartIfRunning && IsRunning)
+			_heartbeatTimer?.Start();
+	}
+
+	public void Start()
+	{
+		if (IsRunning)
+			return;
+
+		IsRunning = true;
+		_heartbeatTimer?.Start();
+		EmitSignal(SignalName.RunningStateChanged, IsRunning);
+	}
+
+	public void Stop()
+	{
+		if (!IsRunning)
+			return;
+
+		IsRunning = false;
+		_heartbeatTimer?.Stop();
+		EmitSignal(SignalName.RunningStateChanged, IsRunning);
+	}
+
+	public bool Publish(string topic, Dictionary payload)
+	{
+		if (!IsRunning || string.IsNullOrWhiteSpace(topic))
+			return false;
+
+		EmitSignal(SignalName.MessageReceived, topic, payload);
+		return true;
+	}
+
+	// DataBindingService and future consumers can register interest by topic.
+	public void RegisterSubscriber(string topic, string subscriberId)
+	{
+		if (string.IsNullOrWhiteSpace(topic) || string.IsNullOrWhiteSpace(subscriberId))
+			return;
+
+		if (!_subscriberIdsByTopic.TryGetValue(topic, out var subscribers))
+		{
+			subscribers = new HashSet<string>(StringComparer.Ordinal);
+			_subscriberIdsByTopic[topic] = subscribers;
+		}
+
+		subscribers.Add(subscriberId);
+	}
+
+	public void UnregisterSubscriber(string topic, string subscriberId)
+	{
+		if (string.IsNullOrWhiteSpace(topic) || string.IsNullOrWhiteSpace(subscriberId))
+			return;
+
+		if (!_subscriberIdsByTopic.TryGetValue(topic, out var subscribers))
+			return;
+
+		subscribers.Remove(subscriberId);
+		if (subscribers.Count == 0)
+			_subscriberIdsByTopic.Remove(topic);
+	}
+
+	public int GetSubscriberCount(string topic)
+	{
+		if (string.IsNullOrWhiteSpace(topic))
+			return 0;
+		return _subscriberIdsByTopic.TryGetValue(topic, out var subscribers) ? subscribers.Count : 0;
+	}
+
+	public Array<string> ListTopics()
+	{
+		var topics = new Array<string>();
+		foreach (var topic in _subscriberIdsByTopic.Keys)
+			topics.Add(topic);
+		return topics;
+	}
+
+	private void EnsureHeartbeatTimer(double intervalSeconds)
+	{
+		if (_heartbeatTimer == null)
+		{
+			_heartbeatTimer = new Timer
+			{
+				Name = "HeartbeatTimer",
+				OneShot = false,
+				Autostart = false,
+			};
+			AddChild(_heartbeatTimer);
+			_heartbeatTimer.Timeout += OnHeartbeatTimeout;
+		}
+
+		_heartbeatTimer.WaitTime = intervalSeconds;
+	}
+
+	private void OnHeartbeatTimeout()
+	{
+		if (!IsRunning)
+			return;
+
+		_heartbeatTick++;
+		var payload = new Dictionary
+		{
+			{ "schema_version", "1.0" },
+			{ "service", "MessageBusService" },
+			{ "kind", "heartbeat" },
+			{ "tick", (long)_heartbeatTick },
+			{ "timestamp", Time.GetDatetimeStringFromSystem(true) },
+		};
+
+		EmitSignal(SignalName.MessageReceived, HeartbeatTopic, payload);
+	}
+}


### PR DESCRIPTION
## Summary
Implements issue #71 by introducing a demo MessageBusService singleton with lifecycle controls and topic subscription registry plumbing.

## What changed
- Added MessageBusService node class in demo scenes:
  - Start()/Stop() lifecycle API
  - Publish(topic, payload) API
  - MessageReceived and RunningStateChanged signals
  - topic->subscriber registry methods (register/unregister/list/count)
  - heartbeat timer emission on bus/status while running
- Main scene setup now instantiates MessageBusService and binds it to DataBindingService
- DataBindingService now maintains per-frame topic subscriptions for demo_stream bindings (excluding desktop frames)

## Validation
- Built demo project successfully:
  - dotnet build demo/GodotChartsDemo.csproj -v minimal

Fixes #71
Refs #55
Refs #69
