### PR TITLE
Wire diegetic console controls to message bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Diegetic console workspace persistence:
 - The active workspace is remembered between runs
 - The console defaults to **hidden** on first run (`F1` to open)
 - Phase 4 scaffold: use the console to create/delete runtime frames, set chart type/size, set frame visual presets, choose per-frame binding mode (`demo_static` or `demo_stream`), and apply environment presets (`daylight`, `studio`, `night`)
+- Data stream control: the console includes explicit `Start Stream`, `Stop Stream`, and `Toggle Stream` controls for the demo message bus. The bus defaults to started on scene load and can be toggled repeatedly during runtime.
 - Desktop runtime frames (`chart_type = desktop`) can be assigned to specific host windows so multiple in-world frames can show different applications simultaneously
 - Runtime frame transforms, chart assignments, binding modes, frame presets, and desktop window selections are saved with the active workspace profile
 - Console now surfaces environment-application status (ready/partial/missing nodes) when applying presets
@@ -247,6 +248,7 @@ Diegetic console workspace persistence:
 - The active workspace is remembered between runs
 - The console defaults to **hidden** on first run (`F1` to open)
 - Phase 4 scaffold: use the console to create/delete runtime frames, set chart type/size, set frame visual presets, choose per-frame binding mode (`demo_static` or `demo_stream`), and apply environment presets (`daylight`, `studio`, `night`)
+- Data stream control: the console includes explicit `Start Stream`, `Stop Stream`, and `Toggle Stream` controls for the demo message bus. The bus defaults to started on scene load and can be toggled repeatedly during runtime.
 - Desktop runtime frames (`chart_type = desktop`) can be assigned to specific host windows so multiple in-world frames can show different applications simultaneously
 - Runtime frame transforms, chart assignments, binding modes, frame presets, and desktop window selections are saved with the active workspace profile
 - Console now surfaces environment-application status (ready/partial/missing nodes) when applying presets

--- a/demo/scenes/ConsoleRoot.cs
+++ b/demo/scenes/ConsoleRoot.cs
@@ -11,6 +11,7 @@ public bool PreferXrInteraction { get; set; }
 private WorkspaceStateService? _workspaceService;
 private FrameOrchestrationService? _frameService;
 private DataBindingService? _bindingService;
+private MessageBusService? _messageBusService;
 private SubViewport? _subViewport;
 private Node3D? _xrViewportHost;
 private OptionButton? _workspacePicker;
@@ -27,6 +28,7 @@ private Label? _environmentStatusLabel;
 private Label? _desktopSourceStatusLabel;
 private Label? _moveModeStatusLabel;
 private Label? _placementStatusLabel;
+private Label? _busStatusLabel;
 
 public bool IsConsoleVisible => Visible;
 
@@ -56,6 +58,19 @@ public void BindBindingService(DataBindingService service)
 _bindingService = service;
 _bindingService.FrameBindingsChanged += RefreshFrameControlsForCurrentSelection;
 RefreshFrameControlsForCurrentSelection();
+}
+
+public void BindMessageBus(MessageBusService service)
+{
+if (_messageBusService == service)
+return;
+
+if (_messageBusService != null)
+_messageBusService.RunningStateChanged -= OnMessageBusRunningStateChanged;
+
+_messageBusService = service;
+_messageBusService.RunningStateChanged += OnMessageBusRunningStateChanged;
+RefreshMessageBusStatus();
 }
 
 public void ToggleConsole()
@@ -148,6 +163,25 @@ column.AddChild(_moveModeStatusLabel);
 
 _placementStatusLabel = new Label { Text = "Placement: idle" };
 column.AddChild(_placementStatusLabel);
+
+_busStatusLabel = new Label { Text = "Data stream bus: pending" };
+column.AddChild(_busStatusLabel);
+
+var busRow = new HBoxContainer();
+busRow.AddThemeConstantOverride("separation", 8);
+column.AddChild(busRow);
+
+var busStartBtn = new Button { Text = "Start Stream" };
+busStartBtn.Pressed += OnStartBusPressed;
+busRow.AddChild(busStartBtn);
+
+var busStopBtn = new Button { Text = "Stop Stream" };
+busStopBtn.Pressed += OnStopBusPressed;
+busRow.AddChild(busStopBtn);
+
+var busToggleBtn = new Button { Text = "Toggle Stream" };
+busToggleBtn.Pressed += OnToggleBusPressed;
+busRow.AddChild(busToggleBtn);
 
 var row = new HBoxContainer();
 row.AddThemeConstantOverride("separation", 8);
@@ -550,6 +584,12 @@ private void OnWorkspaceLoaded(string name)
 if (_statusLabel != null)
 _statusLabel.Text = $"Active workspace: {name}";
 RefreshWorkspaceList();
+RefreshMessageBusStatus();
+}
+
+private void OnMessageBusRunningStateChanged(bool _isRunning)
+{
+RefreshMessageBusStatus();
 }
 
 private void OnWorkspaceSelected(long index)
@@ -779,6 +819,58 @@ return;
 var environmentPreset = _environmentPresetPicker.GetItemText(_environmentPresetPicker.Selected);
 if (_bindingService.SetEnvironmentPreset(environmentPreset))
 _statusLabel!.Text = $"Applied environment preset: {environmentPreset}";
+}
+
+private void OnStartBusPressed()
+{
+if (_messageBusService == null)
+return;
+
+_messageBusService.Start();
+if (_statusLabel != null)
+_statusLabel.Text = "Data stream bus started";
+RefreshMessageBusStatus();
+}
+
+private void OnStopBusPressed()
+{
+if (_messageBusService == null)
+return;
+
+_messageBusService.Stop();
+if (_statusLabel != null)
+_statusLabel.Text = "Data stream bus stopped";
+RefreshMessageBusStatus();
+}
+
+private void OnToggleBusPressed()
+{
+if (_messageBusService == null)
+return;
+
+if (_messageBusService.IsRunning)
+_messageBusService.Stop();
+else
+_messageBusService.Start();
+
+if (_statusLabel != null)
+_statusLabel.Text = _messageBusService.IsRunning ? "Data stream bus started" : "Data stream bus stopped";
+RefreshMessageBusStatus();
+}
+
+private void RefreshMessageBusStatus()
+{
+if (_busStatusLabel == null)
+return;
+
+if (_messageBusService == null)
+{
+_busStatusLabel.Text = "Data stream bus: unavailable";
+return;
+}
+
+var stateText = _messageBusService.IsRunning ? "running" : "stopped";
+_busStatusLabel.Text = $"Data stream bus: {stateText}";
 }
 
 private void OnToggleMoveModePressed()

--- a/demo/scenes/Main.cs
+++ b/demo/scenes/Main.cs
@@ -110,6 +110,7 @@ public partial class Main : Node3D
         _consoleRoot.BindWorkspaceService(_workspaceService);
         _consoleRoot.BindFrameService(_frameService);
         _consoleRoot.BindBindingService(_bindingService);
+        _consoleRoot.BindMessageBus(_messageBusService);
 
         if (_workspaceService.ActiveWorkspaceProfile.TryGetValue("console_visible", out var storedVisible))
             _consoleRoot.SetConsoleVisible(storedVisible.AsBool());


### PR DESCRIPTION
## Summary
Implements issue #73 by wiring diegetic console controls to MessageBusService so demo stream publishing can be started/stopped at runtime.

## What changed
- ConsoleRoot now binds to MessageBusService and listens for running-state changes
- Added explicit console controls:
  - Start Stream
  - Stop Stream
  - Toggle Stream
- Added live bus status label in the console UI
- Main now passes MessageBusService to ConsoleRoot via BindMessageBus(...)
- README demo notes updated with the stream-control interaction flow (desktop + VR sections)

## Acceptance criteria coverage
- Explicit start/stop interaction path: implemented with dedicated buttons
- Default started on scene load: preserved via MessageBusService._Ready()->Start()
- UI reflects current running state: bus status label updates on state changes
- Repeated start/stop safety: handlers are idempotent and build validated
- Flow documented: README sections updated

## Validation
- dotnet build demo/GodotChartsDemo.csproj -v minimal

## Notes
- This PR is stacked on #77 because #73 follows the #71/#72 pipeline chain currently under review.

Fixes #73
Refs #55
Refs #69
