### PR TITLE
Enforce longitudinal ChartData2D sample alignment

### DIFF
--- a/addons/godot-charts/charts_2d/README.md
+++ b/addons/godot-charts/charts_2d/README.md
@@ -31,6 +31,29 @@ chart.y_axes = axes
 chart.chart_data = data
 ```
 
+## Longitudinal data integrity
+
+`ChartData2D` uses one shared category axis. Every dataset must have exactly one
+value for every label:
+
+```gdscript
+assert(data.validation_errors().is_empty())
+```
+
+For live or simulation-driven charts, append a complete sample atomically:
+
+```gdscript
+data.append_sample("D3", {
+    "Stored": 6800.0,
+    "Capture": 82.0,
+})
+```
+
+Dataset labels are the sample keys and must be unique. Category labels must
+also be unique. An omitted dataset receives `NAN`, producing a visible line
+gap instead of shifting later values onto the wrong category. Unknown dataset
+keys and duplicate categories reject the complete append without mutation.
+
 ### Design precedents
 
 The implementation follows established open-source chart patterns:

--- a/addons/godot-charts/charts_2d/chart_data_2d.gd
+++ b/addons/godot-charts/charts_2d/chart_data_2d.gd
@@ -3,17 +3,26 @@ class_name ChartData2D
 extends Resource
 
 ## Shared x-axis labels and parallel numeric datasets.
+##
+## Longitudinal data is aligned by index: every dataset must contain exactly
+## one value for every label. Use append_sample() when streaming categories so
+## the label and every series advance atomically. An omitted series value is
+## stored as NAN, which renderers treat as an intentional gap.
 
 @export var labels := PackedStringArray():
 	set(value):
 		labels = value
-		emit_changed()
+		if not _batching_changes:
+			emit_changed()
 @export var datasets: Array[ChartDataset2D] = []:
 	set(value):
 		_disconnect_datasets()
 		datasets = value
 		_connect_datasets()
-		emit_changed()
+		if not _batching_changes:
+			emit_changed()
+
+var _batching_changes := false
 
 
 func _init(
@@ -41,6 +50,74 @@ func finite_value_range(visible_only: bool = true) -> Variant:
 	return Vector2(minimum, maximum) if found else null
 
 
+func validation_errors() -> PackedStringArray:
+	var errors := PackedStringArray()
+	var category_labels_seen := {}
+	for index in labels.size():
+		var category_label := labels[index]
+		if category_labels_seen.has(category_label):
+			errors.append(
+				"Duplicate category label '%s' at index %d." \
+				% [category_label, index])
+		else:
+			category_labels_seen[category_label] = true
+
+	var dataset_labels_seen := {}
+	for index in datasets.size():
+		var dataset := datasets[index]
+		if dataset == null:
+			errors.append("Dataset at index %d is null." % index)
+			continue
+		if dataset.label.is_empty():
+			errors.append("Dataset at index %d has an empty label." % index)
+		elif dataset_labels_seen.has(dataset.label):
+			errors.append(
+				"Duplicate dataset label '%s' at index %d." \
+				% [dataset.label, index])
+		else:
+			dataset_labels_seen[dataset.label] = true
+		if dataset.values.size() != labels.size():
+			errors.append(
+				"Dataset '%s' has %d values for %d labels." \
+				% [dataset.label, dataset.values.size(), labels.size()])
+	return errors
+
+
+## Adds one shared category and one value per dataset. Missing keys become NAN
+## gaps. Invalid input rejects the complete append without partial mutation.
+func append_sample(category_label: String, values_by_dataset: Dictionary) -> Error:
+	if not validation_errors().is_empty() or labels.has(category_label):
+		return ERR_INVALID_DATA
+	var known_labels := {}
+	for dataset in datasets:
+		known_labels[dataset.label] = true
+	for key in values_by_dataset:
+		if not known_labels.has(str(key)):
+			return ERR_INVALID_PARAMETER
+
+	var next_values: Array[PackedFloat32Array] = []
+	for dataset in datasets:
+		var values := dataset.values.duplicate()
+		var value: float = NAN
+		if values_by_dataset.has(dataset.label):
+			var candidate: Variant = values_by_dataset[dataset.label]
+			if not candidate is int and not candidate is float:
+				return ERR_INVALID_PARAMETER
+			value = float(candidate)
+		values.append(value)
+		next_values.append(values)
+
+	var next_labels := labels.duplicate()
+	next_labels.append(category_label)
+	_batching_changes = true
+	labels = next_labels
+	for index in datasets.size():
+		datasets[index].values = next_values[index]
+	_batching_changes = false
+	emit_changed()
+	return OK
+
+
 func _connect_datasets() -> void:
 	for dataset in datasets:
 		if dataset != null and not dataset.changed.is_connected(_on_dataset_changed):
@@ -54,4 +131,5 @@ func _disconnect_datasets() -> void:
 
 
 func _on_dataset_changed() -> void:
-	emit_changed()
+	if not _batching_changes:
+		emit_changed()

--- a/demo/addons/godot-charts/charts_2d/README.md
+++ b/demo/addons/godot-charts/charts_2d/README.md
@@ -31,6 +31,29 @@ chart.y_axes = axes
 chart.chart_data = data
 ```
 
+## Longitudinal data integrity
+
+`ChartData2D` uses one shared category axis. Every dataset must have exactly one
+value for every label:
+
+```gdscript
+assert(data.validation_errors().is_empty())
+```
+
+For live or simulation-driven charts, append a complete sample atomically:
+
+```gdscript
+data.append_sample("D3", {
+    "Stored": 6800.0,
+    "Capture": 82.0,
+})
+```
+
+Dataset labels are the sample keys and must be unique. Category labels must
+also be unique. An omitted dataset receives `NAN`, producing a visible line
+gap instead of shifting later values onto the wrong category. Unknown dataset
+keys and duplicate categories reject the complete append without mutation.
+
 ### Design precedents
 
 The implementation follows established open-source chart patterns:

--- a/demo/addons/godot-charts/charts_2d/chart_data_2d.gd
+++ b/demo/addons/godot-charts/charts_2d/chart_data_2d.gd
@@ -3,17 +3,26 @@ class_name ChartData2D
 extends Resource
 
 ## Shared x-axis labels and parallel numeric datasets.
+##
+## Longitudinal data is aligned by index: every dataset must contain exactly
+## one value for every label. Use append_sample() when streaming categories so
+## the label and every series advance atomically. An omitted series value is
+## stored as NAN, which renderers treat as an intentional gap.
 
 @export var labels := PackedStringArray():
 	set(value):
 		labels = value
-		emit_changed()
+		if not _batching_changes:
+			emit_changed()
 @export var datasets: Array[ChartDataset2D] = []:
 	set(value):
 		_disconnect_datasets()
 		datasets = value
 		_connect_datasets()
-		emit_changed()
+		if not _batching_changes:
+			emit_changed()
+
+var _batching_changes := false
 
 
 func _init(
@@ -41,6 +50,74 @@ func finite_value_range(visible_only: bool = true) -> Variant:
 	return Vector2(minimum, maximum) if found else null
 
 
+func validation_errors() -> PackedStringArray:
+	var errors := PackedStringArray()
+	var category_labels_seen := {}
+	for index in labels.size():
+		var category_label := labels[index]
+		if category_labels_seen.has(category_label):
+			errors.append(
+				"Duplicate category label '%s' at index %d." \
+				% [category_label, index])
+		else:
+			category_labels_seen[category_label] = true
+
+	var dataset_labels_seen := {}
+	for index in datasets.size():
+		var dataset := datasets[index]
+		if dataset == null:
+			errors.append("Dataset at index %d is null." % index)
+			continue
+		if dataset.label.is_empty():
+			errors.append("Dataset at index %d has an empty label." % index)
+		elif dataset_labels_seen.has(dataset.label):
+			errors.append(
+				"Duplicate dataset label '%s' at index %d." \
+				% [dataset.label, index])
+		else:
+			dataset_labels_seen[dataset.label] = true
+		if dataset.values.size() != labels.size():
+			errors.append(
+				"Dataset '%s' has %d values for %d labels." \
+				% [dataset.label, dataset.values.size(), labels.size()])
+	return errors
+
+
+## Adds one shared category and one value per dataset. Missing keys become NAN
+## gaps. Invalid input rejects the complete append without partial mutation.
+func append_sample(category_label: String, values_by_dataset: Dictionary) -> Error:
+	if not validation_errors().is_empty() or labels.has(category_label):
+		return ERR_INVALID_DATA
+	var known_labels := {}
+	for dataset in datasets:
+		known_labels[dataset.label] = true
+	for key in values_by_dataset:
+		if not known_labels.has(str(key)):
+			return ERR_INVALID_PARAMETER
+
+	var next_values: Array[PackedFloat32Array] = []
+	for dataset in datasets:
+		var values := dataset.values.duplicate()
+		var value: float = NAN
+		if values_by_dataset.has(dataset.label):
+			var candidate: Variant = values_by_dataset[dataset.label]
+			if not candidate is int and not candidate is float:
+				return ERR_INVALID_PARAMETER
+			value = float(candidate)
+		values.append(value)
+		next_values.append(values)
+
+	var next_labels := labels.duplicate()
+	next_labels.append(category_label)
+	_batching_changes = true
+	labels = next_labels
+	for index in datasets.size():
+		datasets[index].values = next_values[index]
+	_batching_changes = false
+	emit_changed()
+	return OK
+
+
 func _connect_datasets() -> void:
 	for dataset in datasets:
 		if dataset != null and not dataset.changed.is_connected(_on_dataset_changed):
@@ -54,4 +131,5 @@ func _disconnect_datasets() -> void:
 
 
 func _on_dataset_changed() -> void:
-	emit_changed()
+	if not _batching_changes:
+		emit_changed()

--- a/tests/charts_2d/godot/test_charts_2d.gd
+++ b/tests/charts_2d/godot/test_charts_2d.gd
@@ -17,6 +17,8 @@ func _init() -> void:
 
 func _run() -> void:
 	_test_data_range()
+	_test_longitudinal_data_contract()
+	_test_atomic_sample_append()
 	_test_domain_behavior()
 	_test_category_positions()
 	_test_dataset_change_propagation()
@@ -47,6 +49,65 @@ func _test_data_range() -> void:
 	])
 	_expect(empty.finite_value_range() == null,
 		"All-non-finite data must return an empty range.")
+
+
+func _test_longitudinal_data_contract() -> void:
+	var valid = ChartData.new(PackedStringArray(["D0", "D1"]), [
+		ChartDataset.new("water", PackedFloat32Array([10.0, 8.0])),
+		ChartDataset.new("air", PackedFloat32Array([90.0, 85.0])),
+	])
+	_expect(valid.validation_errors().is_empty(),
+		"Aligned longitudinal data must validate.")
+
+	var mismatched = ChartData.new(PackedStringArray(["D0", "D1"]), [
+		ChartDataset.new("water", PackedFloat32Array([10.0])),
+	])
+	_expect(mismatched.validation_errors() == PackedStringArray([
+		"Dataset 'water' has 1 values for 2 labels."]),
+		"Mismatched series must report a deterministic alignment error.")
+
+	var duplicates = ChartData.new(PackedStringArray(["D0", "D0"]), [
+		ChartDataset.new("water", PackedFloat32Array([10.0, 8.0])),
+		ChartDataset.new("water", PackedFloat32Array([90.0, 85.0])),
+	])
+	var duplicate_errors := duplicates.validation_errors()
+	_expect(duplicate_errors.has("Duplicate category label 'D0' at index 1."),
+		"Duplicate category labels must be rejected.")
+	_expect(duplicate_errors.has("Duplicate dataset label 'water' at index 1."),
+		"Duplicate dataset labels must be rejected.")
+
+
+func _test_atomic_sample_append() -> void:
+	var water = ChartDataset.new("water", PackedFloat32Array([10.0]))
+	var air = ChartDataset.new("air", PackedFloat32Array([90.0]))
+	var data = ChartData.new(PackedStringArray(["D0"]), [water, air])
+	_change_count = 0
+	data.changed.connect(_on_data_changed)
+
+	var result: Error = data.append_sample("D1", {"water": 8.0})
+	_expect(result == OK, "A valid sample append must succeed.")
+	_expect(data.labels == PackedStringArray(["D0", "D1"]),
+		"Atomic append must add the shared category label.")
+	_expect(water.values == PackedFloat32Array([10.0, 8.0]),
+		"Atomic append must add provided series values.")
+	_expect(air.values.size() == 2 and is_nan(air.values[1]),
+		"Missing series values must append as explicit NAN gaps.")
+	_expect(_change_count == 1,
+		"Atomic append must invalidate owning chart data exactly once.")
+
+	var labels_before: PackedStringArray = data.labels.duplicate()
+	var water_before: PackedFloat32Array = water.values.duplicate()
+	result = data.append_sample("D1", {"water": 7.0})
+	_expect(result == ERR_INVALID_DATA,
+		"Duplicate categories must fail.")
+	_expect(data.labels == labels_before and water.values == water_before,
+		"A rejected duplicate category must not partially mutate data.")
+
+	result = data.append_sample("D2", {"unknown": 1.0})
+	_expect(result == ERR_INVALID_PARAMETER,
+		"Unknown dataset keys must fail.")
+	_expect(data.labels == labels_before and water.values == water_before,
+		"A rejected unknown series must not partially mutate data.")
 
 
 func _test_domain_behavior() -> void:
@@ -93,6 +154,7 @@ func _test_category_positions() -> void:
 func _test_dataset_change_propagation() -> void:
 	var dataset = ChartDataset.new("series", PackedFloat32Array([1.0]))
 	var data = ChartData.new(PackedStringArray(["1"]), [dataset])
+	_change_count = 0
 	data.changed.connect(_on_data_changed)
 	dataset.values = PackedFloat32Array([2.0])
 	_expect(_change_count == 1,


### PR DESCRIPTION
## Summary
- validate shared category labels against every dataset length
- append longitudinal samples atomically across all series
- encode missing values as NAN gaps instead of shifting later data
- reject duplicate categories and unknown dataset keys without partial mutation
- document the data contract and cover success, missing, rollback, and error cases

Closes #98

## Validation
- bash scripts/test-charts-2d.sh
- git diff --cached --check