### PR TITLE
docs(openspec): capture billboard chart adoption from burb-sweeper

### DIFF
--- a/openspec/changes/adopt-billboard-chart-modules/proposal.md
+++ b/openspec/changes/adopt-billboard-chart-modules/proposal.md
@@ -1,0 +1,47 @@
+# Adopt burb-sweeper's Billboard Chart Modules
+
+## Status
+**Design capture - cross-repo contract.** Created from burb-sweeper's
+pre-implementation design review (2026-07-30), which fixed the code
+partition: main game (burb-sweeper), godot-charts (chart rendering),
+automate-godot (portable rules cores). This change is the
+godot-charts side of that partition for the billboard charts.
+
+## Why
+
+burb-sweeper ships in-world metric billboards whose chart rendering
+lives game-side today: line charts drawn into billboard SubViewport
+surfaces, fed by a `MetricSeriesAdapter` seam over the game's
+longitudinal metrics, organized into chart groups (survival stocks,
+population, and the FAUCETS AND DRAINS ledger group). That rendering
+is chart code, not game code - by the partition it belongs here, and
+the compact billboard chart work already landing on this repo's
+billboard branch is the natural home for it.
+
+Adopting it gives godot-charts a real, shipping consumer with a
+concrete contract to satisfy - the same first-consumer discipline
+automate-godot uses with the crafting core.
+
+## What Changes
+
+- **Absorb the billboard chart feature set** as addon capabilities:
+  compact multi-series line charts sized for in-world billboard
+  surfaces, grouped series with group titles, day-indexed x-axes,
+  render-on-change friendliness (the game renders billboard surfaces
+  UPDATE_ONCE on content change for performance).
+- **Define the data contract at the boundary**: the game keeps
+  `MetricSeriesAdapter` (game types, game state) and hands the addon
+  plain series data - labels, points, group metadata. No burb-sweeper
+  types cross into the addon; mirror the isolation-guard pattern
+  burb-sweeper's recipe core uses for automate-godot.
+- **Replacement plan**: once the addon's billboard charts reach
+  parity, burb-sweeper's game-side chart drawing is replaced by addon
+  consumption; the game-side seam and billboard/composition plumbing
+  stay game-side.
+
+## Non-goals
+
+- Billboard placement, composition-camera integration, SubViewport
+  ownership - game-side presentation, stays in burb-sweeper.
+- Blocking this repo's XR/data-science direction on the game's needs:
+  the billboard charts are one consumer, not the architecture.

--- a/openspec/changes/adopt-billboard-chart-modules/specs/billboard-adoption/spec.md
+++ b/openspec/changes/adopt-billboard-chart-modules/specs/billboard-adoption/spec.md
@@ -1,0 +1,35 @@
+# Billboard Adoption
+
+## ADDED Requirements
+
+### Requirement: The addon serves billboard-scale charts
+The addon SHALL provide compact multi-series line charts suitable for
+in-world billboard surfaces - grouped series with titles, day-indexed
+axes, legible at billboard resolution - covering the feature set
+burb-sweeper's game-side billboard charts ship today.
+
+#### Scenario: The game's charts have an addon equivalent
+- **WHEN** the adoption reaches parity
+- **THEN** each of burb-sweeper's billboard chart groups (stocks,
+  population, ledger) renders through the addon with no visual
+  regression
+
+### Requirement: The boundary carries data, not game types
+The addon SHALL accept plain series data - labels, points, group
+metadata - at its boundary, with no consumer types imported; the
+consumer's adapter (burb-sweeper's MetricSeriesAdapter) owns the
+translation on its own side.
+
+#### Scenario: Isolation holds both ways
+- **WHEN** the addon is scanned for consumer references
+- **THEN** none exist, mirroring the isolation guard burb-sweeper's
+  portable cores enforce
+
+### Requirement: Rendering is render-on-change friendly
+Chart rendering SHALL support redraw-on-data-change usage so consumers
+rendering to update-once viewport surfaces pay draw cost only when
+content changes.
+
+#### Scenario: The static chart costs nothing
+- **WHEN** a chart's data is unchanged across frames
+- **THEN** no per-frame redraw work is required of the consumer

--- a/openspec/changes/adopt-billboard-chart-modules/tasks.md
+++ b/openspec/changes/adopt-billboard-chart-modules/tasks.md
@@ -1,0 +1,18 @@
+## Tasks
+
+- [ ] Inventory burb-sweeper's billboard chart surface: chart module
+      scripts, series/group shapes MetricSeriesAdapter emits, the
+      ledger group's needs (paired faucet/drain series), billboard
+      resolution constraints.
+- [ ] Map that inventory onto the compact billboard chart work already
+      on this repo's billboard branch; gap-list what parity requires.
+- [ ] Define the boundary data shape (series, labels, points, group
+      metadata) as typed GDScript with no consumer types; add an
+      isolation check mirroring burb-sweeper's recipe-registry guard.
+- [ ] Parity build: grouped compact line charts, day-indexed axes,
+      billboard-legible styling, render-on-change contract.
+- [ ] Consumer cutover (tracked burb-sweeper-side): game chart drawing
+      replaced by addon calls behind MetricSeriesAdapter; visual
+      parity check on the real billboards.
+- [ ] Record the adoption in both repos' docs (burb-sweeper systems
+      map already notes the destination).


### PR DESCRIPTION
Cross-repo contract from burb-sweeper's 2026-07-30 code-partition decision (main game / godot-charts / automate-godot): the in-world billboard chart rendering shipping game-side in burb-sweeper belongs here.

New change `adopt-billboard-chart-modules`: the billboard chart feature set as addon capabilities (compact grouped line charts, day-indexed axes, billboard-legible), a plain-data boundary with an isolation guard (no consumer types cross - burb-sweeper keeps MetricSeriesAdapter on its side), a render-on-change contract for update-once viewport consumers, and a parity-then-cutover plan. Aligns with the compact billboard chart work already on feature/billboard-charts-2d - task two maps the inventory onto it.

Docs-only; `openspec validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)