### PR TITLE
Show latest values in 2D chart legends

### DIFF
--- a/addons/godot-charts/charts_2d/README.md
+++ b/addons/godot-charts/charts_2d/README.md
@@ -77,3 +77,11 @@ Accordingly, `LineChart2D`:
 Multiple axes increase comparison risk. Prefer one shared axis for compatible
 units and small multiples when many independent scales make the plot harder to
 read. Explicit axes are a deliberate choice, never inferred from magnitude.
+
+## Current values in legends
+
+Set `show_latest_values` when a live chart must communicate its current value
+as well as its trend. The legend then appends the last finite sample for each
+visible dataset. This also keeps a new one-sample series informative before a
+second point exists to form a line. The option defaults to `false` so ordinary
+legends retain their compact labels.

--- a/addons/godot-charts/charts_2d/line_chart_2d.gd
+++ b/addons/godot-charts/charts_2d/line_chart_2d.gd
@@ -53,6 +53,10 @@ var _y_axes: Array[Resource] = []
 	set(value):
 		show_legend = value
 		queue_redraw()
+@export var show_latest_values := false:
+	set(value):
+		show_latest_values = value
+		queue_redraw()
 @export var show_x_labels := true:
 	set(value):
 		show_x_labels = value
@@ -183,6 +187,35 @@ static func category_unit(index: int, category_count: int) -> float:
 		0.0,
 		1.0
 	)
+
+
+static func latest_finite_value(dataset: Resource) -> Variant:
+	if dataset == null or not "values" in dataset:
+		return null
+	for index in range(dataset.values.size() - 1, -1, -1):
+		var value: float = dataset.values[index]
+		if is_finite(value):
+			return value
+	return null
+
+
+static func legend_text(dataset: Resource, include_latest_value: bool) -> String:
+	if dataset == null:
+		return ""
+	var result := str(dataset.label)
+	if not include_latest_value:
+		return result
+	var latest: Variant = latest_finite_value(dataset)
+	if latest == null:
+		return result
+	return "%s  %s" % [result, _format_display_value(float(latest))]
+
+
+static func _format_display_value(value: float) -> String:
+	var magnitude := absf(value)
+	if magnitude >= 1.0e6 or (magnitude > 0.0 and magnitude < 1.0e-4):
+		return "%.3e" % value
+	return String.num(value, 2)
 
 
 func _plot_rect() -> Rect2:
@@ -393,18 +426,19 @@ func _draw_header(colors: ChartPalette2D) -> void:
 		if dataset == null or not dataset.visible:
 			continue
 		var color := dataset.color if dataset.color.a > 0.0 else colors.series_color(index)
+		var label := legend_text(dataset, show_latest_values)
 		draw_line(Vector2(x, y - 5.0), Vector2(x + 24.0, y - 5.0), color, line_width)
 		draw_string(
 			ThemeDB.fallback_font,
 			Vector2(x + 32.0, y),
-			dataset.label,
+			label,
 			HORIZONTAL_ALIGNMENT_LEFT,
 			-1.0,
 			ThemeDB.fallback_font_size,
 			colors.foreground
 		)
 		x += 48.0 + ThemeDB.fallback_font.get_string_size(
-			dataset.label,
+			label,
 			HORIZONTAL_ALIGNMENT_LEFT,
 			-1.0,
 			ThemeDB.fallback_font_size

--- a/tests/charts_2d/godot/test_charts_2d.gd
+++ b/tests/charts_2d/godot/test_charts_2d.gd
@@ -21,6 +21,7 @@ func _run() -> void:
 	_test_atomic_sample_append()
 	_test_domain_behavior()
 	_test_category_positions()
+	_test_latest_value_legend()
 	_test_dataset_change_propagation()
 	_test_palette_slots()
 	_test_multiple_y_axes()
@@ -149,6 +150,20 @@ func _test_category_positions() -> void:
 	_expect(LineChart.category_unit(0, 2) == 0.0 \
 			and LineChart.category_unit(1, 2) == 1.0,
 		"Two samples must span the full horizontal domain.")
+
+
+func _test_latest_value_legend() -> void:
+	var dataset = ChartDataset.new(
+		"Water", PackedFloat32Array([3578.0, NAN, 3499.25]))
+	_expect(LineChart.latest_finite_value(dataset) == 3499.25,
+		"Latest values must skip trailing non-finite gaps.")
+	_expect(LineChart.legend_text(dataset, true) == "Water  3499.25",
+		"The optional legend value must expose the latest finite sample.")
+	_expect(LineChart.legend_text(dataset, false) == "Water",
+		"Latest values must remain opt-in for compatibility.")
+	var empty = ChartDataset.new("Empty", PackedFloat32Array([NAN]))
+	_expect(LineChart.legend_text(empty, true) == "Empty",
+		"A series without a finite sample must keep its ordinary label.")
 
 
 func _test_dataset_change_propagation() -> void:


### PR DESCRIPTION
Adds an opt-in legend mode that exposes each visible series' latest finite value. This makes one-sample live charts informative before a trend line exists, while retaining compact legends by default. Includes focused contract coverage and package documentation.